### PR TITLE
fix: invalid http verb for manage security identities

### DIFF
--- a/src/push_api_clientpy/platformclient.py
+++ b/src/push_api_clientpy/platformclient.py
@@ -147,7 +147,7 @@ class PlatformClient:
         url = f'{self.__baseProviderURL(securityProviderId)}/permissions/batch'
         queryParams = {"fileId": batchConfig.FileID,
                        "orderingId": batchConfig.OrderingID}
-        return requests.delete(url, params=queryParams, headers=headers)
+        return requests.put(url, params=queryParams, headers=headers)
 
     def pushDocument(self, sourceId: str, doc):
         headers = self.__authorizationHeader() | self.__contentTypeApplicationJSONHeader()

--- a/tests/test_platformclient.py
+++ b/tests/test_platformclient.py
@@ -1,6 +1,6 @@
 import pytest
 import requests
-from push_api_clientpy import IdentityModel, PlatformClient, SecurityIdentityModel, SecurityIdentityAliasModel, AliasMapping, SecurityIdentityDelete, DocumentBuilder, BatchDelete, BatchUpdateDocuments, FileContainer
+from push_api_clientpy import IdentityModel, PlatformClient, SecurityIdentityModel, SecurityIdentityAliasModel, AliasMapping, SecurityIdentityDelete, DocumentBuilder, BatchDelete, BatchUpdateDocuments, FileContainer, SecurityIdentityBatchConfig
 
 
 @pytest.fixture
@@ -26,6 +26,10 @@ def securityIdentityModelAlias(identityModel):
 @pytest.fixture
 def securityIdentityDelete(identityModel):
     return SecurityIdentityDelete(Identity=identityModel)
+
+@pytest.fixture
+def securityIdentityBatchConfig():
+    return SecurityIdentityBatchConfig(FileID="the_file_id", OrderingID=123)
 
 
 @pytest.fixture
@@ -113,6 +117,14 @@ class TestPlatformClient:
 
         assert lastRequestBody.get("identity").get("name") == "the_name"
 
+        assertAuthHeader(adapter)
+        assertContentTypeHeaders(adapter)
+
+    def testManageSecurityIdentities(self, client, requests_mock, securityIdentityBatchConfig):
+        adapter = requests_mock.put(
+            f"https://api.cloud.coveo.com/push/v1/organizations/my_org/providers/my_provider/permissions/batch?fileId={securityIdentityBatchConfig.FileID}&orderingId={securityIdentityBatchConfig.OrderingID}", json={})
+        client.manageSecurityIdentities(
+            "my_provider", securityIdentityBatchConfig)
         assertAuthHeader(adapter)
         assertContentTypeHeaders(adapter)
 


### PR DESCRIPTION
Should be PUT instead of DELETE.

Also added missing UT.

https://coveord.atlassian.net/browse/CDX-419