### PR TITLE
replace hash-sha256 by md5+sha1

### DIFF
--- a/src/push_api_clientpy/documentbuilder.py
+++ b/src/push_api_clientpy/documentbuilder.py
@@ -104,8 +104,11 @@ class DocumentBuilder:
         return withoutEmptyValue
 
     def __generatePermanentId(self):
-        self.document.permanentId = hashlib.sha256(
-            self.document.uri.encode('utf-8')).hexdigest()
+        # generate a 60-character id
+        utf8 = self.document.uri.encode('utf-8')
+        md5 = hashlib.md5(utf8)
+        sha1 = hashlib.sha1(utf8)
+        self.document.permanentId = md5.hexdigest()[:30] + sha1.hexdigest()[:30]
 
     def __validateDateAndReturnValidDate(self, date: Union[str, int, datetime]) -> str:
         dateAsDatetime = datetime.now()

--- a/tests/test_docbuilder.py
+++ b/tests/test_docbuilder.py
@@ -69,8 +69,8 @@ class TestDocBuilder:
         assert docBuilder.marshal().get("permanentId") == "the_id"
 
     def testMarshalDocumentPermanentIdFromURI(self, docBuilder):
-        assert docBuilder.marshal().get("permanentId") == hashlib.sha256(
-            "https://foo.com".encode("utf-8")).hexdigest()
+        # 'https://foo.com'
+        assert docBuilder.marshal().get("permanentId") == 'aa2e0510b66edff7f05e2b30d4f1b3a4b5481c06b69f41751c54675c5afb'
 
     def testMarshalFileExtension(self, docBuilder):
         docBuilder.withFileExtension(".html")


### PR DESCRIPTION
The limit for `permanentid` in the index is actually 60 characters. hashlib.sha256() is generating a 64-character hash. 

Rather than simply truncating it, I am proposing the default algorithm to generate permanentid in the index: `md5[:30]+sha1[:30]`