### PR TITLE
chore: include client details in header

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,14 +63,17 @@ Dev
 * Tests: ``pipenv run tox``
 * Full list of commands: ``pipenv run tox -av``
 
-Release
-=======
+Versioning and Publishing to PyPI
+=================================
 
-After merging into master the feature branch for which you would like to publish:
+Before merging a feature branch into master, you must update the package version of your branch:
 
-* Checkout the latest version of master on local
 * Open ``pyproject.toml`` in the text editor of your choice
 * Under ``[project]``, update the ``version``, following semantic versioning format (``v{Major}.{Minor}.{Patch}``)
+
+Once the feature branch you would like to publish has been merged into master:
+
+* Checkout the latest version of master on local
 * Run ``pipenv run tox -e clean``
 * Run ``pipenv run tox -e build``
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version_scheme = "no-guess-dev"
 
 [project]
 name = "coveo-push-api-client.py"
-version = "1.1.1"
+version = "1.1.2"
 description = "Python Push API Client"
 readme = "README.rst"
 requires-python = ">=3.9"

--- a/src/push_api_clientpy/platformclient.py
+++ b/src/push_api_clientpy/platformclient.py
@@ -126,6 +126,7 @@ class PlatformClient:
                         )
         session.mount('https://', HTTPAdapter(max_retries=self.retries))
         self.session = session
+        self.version = importlib.metadata.version('coveo-push-api-client.py')
 
     def createSource(self, name: str, sourceVisibility: SourceVisibility):
         data = {
@@ -207,5 +208,4 @@ class PlatformClient:
         return {'Content-Type': 'application/json', 'Accept': 'application/json'}
 
     def __userAgentHeader(self):
-        version = importlib.metadata.version('coveo-push-api-client.py')
-        return {'User-Agent': f'CoveoPythonSDK/{version}'}
+        return {'User-Agent': f'CoveoPythonSDK/{self.version}'}

--- a/src/push_api_clientpy/platformclient.py
+++ b/src/push_api_clientpy/platformclient.py
@@ -208,4 +208,4 @@ class PlatformClient:
         return {'Content-Type': 'application/json', 'Accept': 'application/json'}
 
     def __userAgentHeader(self):
-        return {'User-Agent': f'CoveoPythonSDK/{self.version}'}
+        return {'User-Agent': f'CoveoSDKPython/{self.version}'}

--- a/tests/test_platformclient.py
+++ b/tests/test_platformclient.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import pytest
 import requests
 from push_api_clientpy import IdentityModel, PlatformClient, SecurityIdentityModel, SecurityIdentityAliasModel, AliasMapping, SecurityIdentityDelete, DocumentBuilder, BatchDelete, BatchUpdateDocuments, FileContainer, SecurityIdentityBatchConfig, BackoffOptions
@@ -51,6 +52,11 @@ def assertContentTypeHeaders(adapter):
     assert lastRequestHeaders.get("Content-Type") == "application/json"
     assert lastRequestHeaders.get("Accept") == "application/json"
 
+def assertUserAgentHeaders(adapter):
+    lastRequestHeaders = adapter.last_request.headers
+    version = importlib.metadata.version('coveo-push-api-client.py')
+    assert lastRequestHeaders.get("User-Agent") == f'CoveoPythonSDK/{version}'
+
 
 class TestPlatformClient:
 
@@ -67,6 +73,7 @@ class TestPlatformClient:
 
         assertAuthHeader(adapter)
         assertContentTypeHeaders(adapter)
+        assertUserAgentHeaders(adapter)
 
     def testCreateOrUpdateSecurityIdentity(self, client, requests_mock, securityIdentityModel):
         adapter = requests_mock.put(
@@ -86,6 +93,7 @@ class TestPlatformClient:
 
         assertAuthHeader(adapter)
         assertContentTypeHeaders(adapter)
+        assertUserAgentHeaders(adapter)
 
     def testCreateOrUpdateSecurityIdentityAlias(self, client, requests_mock, securityIdentityModelAlias):
         adapter = requests_mock.put(
@@ -106,6 +114,7 @@ class TestPlatformClient:
 
         assertAuthHeader(adapter)
         assertContentTypeHeaders(adapter)
+        assertUserAgentHeaders(adapter)
 
     def testDeleteSecurityIdentity(self, client, requests_mock, securityIdentityDelete):
         adapter = requests_mock.delete(
@@ -118,6 +127,7 @@ class TestPlatformClient:
 
         assertAuthHeader(adapter)
         assertContentTypeHeaders(adapter)
+        assertUserAgentHeaders(adapter)
 
     def testManageSecurityIdentities(self, client, requests_mock, securityIdentityBatchConfig):
         adapter = requests_mock.put(
@@ -126,6 +136,7 @@ class TestPlatformClient:
             "my_provider", securityIdentityBatchConfig)
         assertAuthHeader(adapter)
         assertContentTypeHeaders(adapter)
+        assertUserAgentHeaders(adapter)
 
     def testPushDocument(self, client, requests_mock, doc):
         adapter = requests_mock.put(
@@ -138,6 +149,7 @@ class TestPlatformClient:
 
         assertAuthHeader(adapter)
         assertContentTypeHeaders(adapter)
+        assertUserAgentHeaders(adapter)
 
     def testCreateFileContainer(self, client, requests_mock):
         adapter = requests_mock.post(
@@ -146,6 +158,7 @@ class TestPlatformClient:
 
         assertAuthHeader(adapter)
         assertContentTypeHeaders(adapter)
+        assertUserAgentHeaders(adapter)
 
     def testUploadContentToFileContainer(self, client, requests_mock, fileContainer, doc):
         adapter = requests_mock.put(fileContainer.uploadUri)
@@ -168,6 +181,7 @@ class TestPlatformClient:
 
         assertAuthHeader(adapter)
         assertContentTypeHeaders(adapter)
+        assertUserAgentHeaders(adapter)
 
     def testDeleteDocument(self, client, requests_mock):
         adapter = requests_mock.delete(
@@ -176,6 +190,7 @@ class TestPlatformClient:
 
         assertAuthHeader(adapter)
         assertContentTypeHeaders(adapter)
+        assertUserAgentHeaders(adapter)
 
     def testRetryMechanismOptions(self):
         new_client = PlatformClient("my_key", "my_org", BackoffOptions(retry_after=100, max_retries=10))

--- a/tests/test_platformclient.py
+++ b/tests/test_platformclient.py
@@ -1,6 +1,4 @@
-import importlib.metadata
 import pytest
-import requests
 from push_api_clientpy import IdentityModel, PlatformClient, SecurityIdentityModel, SecurityIdentityAliasModel, AliasMapping, SecurityIdentityDelete, DocumentBuilder, BatchDelete, BatchUpdateDocuments, FileContainer, SecurityIdentityBatchConfig, BackoffOptions
 
 
@@ -52,11 +50,6 @@ def assertContentTypeHeaders(adapter):
     assert lastRequestHeaders.get("Content-Type") == "application/json"
     assert lastRequestHeaders.get("Accept") == "application/json"
 
-def assertUserAgentHeaders(adapter):
-    lastRequestHeaders = adapter.last_request.headers
-    version = importlib.metadata.version('coveo-push-api-client.py')
-    assert lastRequestHeaders.get("User-Agent") == f'CoveoPythonSDK/{version}'
-
 
 class TestPlatformClient:
 
@@ -73,7 +66,6 @@ class TestPlatformClient:
 
         assertAuthHeader(adapter)
         assertContentTypeHeaders(adapter)
-        assertUserAgentHeaders(adapter)
 
     def testCreateOrUpdateSecurityIdentity(self, client, requests_mock, securityIdentityModel):
         adapter = requests_mock.put(
@@ -93,7 +85,6 @@ class TestPlatformClient:
 
         assertAuthHeader(adapter)
         assertContentTypeHeaders(adapter)
-        assertUserAgentHeaders(adapter)
 
     def testCreateOrUpdateSecurityIdentityAlias(self, client, requests_mock, securityIdentityModelAlias):
         adapter = requests_mock.put(
@@ -114,7 +105,6 @@ class TestPlatformClient:
 
         assertAuthHeader(adapter)
         assertContentTypeHeaders(adapter)
-        assertUserAgentHeaders(adapter)
 
     def testDeleteSecurityIdentity(self, client, requests_mock, securityIdentityDelete):
         adapter = requests_mock.delete(
@@ -127,7 +117,6 @@ class TestPlatformClient:
 
         assertAuthHeader(adapter)
         assertContentTypeHeaders(adapter)
-        assertUserAgentHeaders(adapter)
 
     def testManageSecurityIdentities(self, client, requests_mock, securityIdentityBatchConfig):
         adapter = requests_mock.put(
@@ -136,7 +125,6 @@ class TestPlatformClient:
             "my_provider", securityIdentityBatchConfig)
         assertAuthHeader(adapter)
         assertContentTypeHeaders(adapter)
-        assertUserAgentHeaders(adapter)
 
     def testPushDocument(self, client, requests_mock, doc):
         adapter = requests_mock.put(
@@ -149,7 +137,6 @@ class TestPlatformClient:
 
         assertAuthHeader(adapter)
         assertContentTypeHeaders(adapter)
-        assertUserAgentHeaders(adapter)
 
     def testCreateFileContainer(self, client, requests_mock):
         adapter = requests_mock.post(
@@ -158,7 +145,6 @@ class TestPlatformClient:
 
         assertAuthHeader(adapter)
         assertContentTypeHeaders(adapter)
-        assertUserAgentHeaders(adapter)
 
     def testUploadContentToFileContainer(self, client, requests_mock, fileContainer, doc):
         adapter = requests_mock.put(fileContainer.uploadUri)
@@ -181,7 +167,6 @@ class TestPlatformClient:
 
         assertAuthHeader(adapter)
         assertContentTypeHeaders(adapter)
-        assertUserAgentHeaders(adapter)
 
     def testDeleteDocument(self, client, requests_mock):
         adapter = requests_mock.delete(
@@ -190,7 +175,6 @@ class TestPlatformClient:
 
         assertAuthHeader(adapter)
         assertContentTypeHeaders(adapter)
-        assertUserAgentHeaders(adapter)
 
     def testRetryMechanismOptions(self):
         new_client = PlatformClient("my_key", "my_org", BackoffOptions(retry_after=100, max_retries=10))


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2803

Very similar to my NodeJS SDK change. There's a slightly less awkward way of retrieving the current package version here by leveraging [importlib.metadata](https://docs.python.org/3/library/importlib.metadata.html).

I created a temporary UT to ensure that the local `version` is fetched rather than the latest published `version` (the docs were a bit unclear, so I wanted to test for myself). I later deleted this test because it doesn't feel necessary to test whether we can read the same field using the same method in 2 different places. If anyone feels strongly about having a test for this, I'll add it back as it doesn't add any overhead 🤷 