### PR TITLE
Add missing param deleteChildren

### DIFF
--- a/src/push_api_clientpy/source.py
+++ b/src/push_api_clientpy/source.py
@@ -36,7 +36,7 @@ class Source:
         return self.client.pushDocument(sourceId, docBuilder.marshal())
 
     def deleteDocument(self, sourceId: str, documentId: str, deleteChildren: bool):
-        return self.client.deleteDocument(sourceId, documentId, deleteChildren: bool)
+        return self.client.deleteDocument(sourceId, documentId, deleteChildren)
 
     def batchUpdateDocuments(self, sourceId: str, batch: BatchUpdate):
         resFileContainer = self.client.createFileContainer().json()

--- a/src/push_api_clientpy/source.py
+++ b/src/push_api_clientpy/source.py
@@ -35,8 +35,8 @@ class Source:
     def addOrUpdateDocument(self, sourceId: str, docBuilder: DocumentBuilder):
         return self.client.pushDocument(sourceId, docBuilder.marshal())
 
-    def deleteDocument(self, sourceId: str, documentId: str):
-        return self.client.deleteDocument(sourceId, documentId)
+    def deleteDocument(self, sourceId: str, documentId: str, deleteChildren: bool):
+        return self.client.deleteDocument(sourceId, documentId, deleteChildren: bool)
 
     def batchUpdateDocuments(self, sourceId: str, batch: BatchUpdate):
         resFileContainer = self.client.createFileContainer().json()


### PR DESCRIPTION
**Context**
deleteDocument method in source is missing deleteChildren param required by platform's client method deleteChildren.

**AC**
 - Add deleteChildren param to deleteDocument method in source.