### PR TITLE
Suggesting a fix to the platformclient so a region can be specified t…

### DIFF
--- a/src/push_api_clientpy/platformclient.py
+++ b/src/push_api_clientpy/platformclient.py
@@ -114,10 +114,11 @@ class BackoffOptions:
 
 
 class PlatformClient:
-    def __init__(self, apikey: str, organizationid: str, backoff_options: BackoffOptions = BackoffOptions(), session = requests.Session()):
+    def __init__(self, apikey: str, organizationid: str, backoff_options: BackoffOptions = BackoffOptions(), region = 'us', session = requests.Session()):
         self.apikey = apikey
         self.organizationid = organizationid
         self.backoff_options = backoff_options
+        self.region = region
 
         self.retries = Retry(total=self.backoff_options.max_retries,
                         backoff_factor=self.backoff_options.retry_after,
@@ -187,10 +188,10 @@ class PlatformClient:
         return self.session.put(url=url, params=queryParams, headers=self.__headers())
 
     def __basePushURL(self):
-        return f'https://api.cloud.coveo.com/push/v1/organizations/{self.organizationid}'
+        return f'https://api-{self.region}.cloud.coveo.com/push/v1/organizations/{self.organizationid}'
 
     def __basePlatformURL(self):
-        return f'https://platform.cloud.coveo.com/rest/organizations/{self.organizationid}'
+        return f'https://platform-{self.region}.cloud.coveo.com/rest/organizations/{self.organizationid}'
 
     def __baseSourceURL(self):
         return f'{self.__basePlatformURL()}/sources'

--- a/src/push_api_clientpy/source.py
+++ b/src/push_api_clientpy/source.py
@@ -11,8 +11,8 @@ class BatchUpdate(BatchUpdateDocuments):
 
 
 class Source:
-    def __init__(self, apikey: str, organizationid: str, backoff_options: BackoffOptions = BackoffOptions()):
-        self.client = PlatformClient(apikey, organizationid, backoff_options)
+    def __init__(self, apikey: str, organizationid: str, backoff_options: BackoffOptions = BackoffOptions(), region = 'us'):
+        self.client = PlatformClient(apikey, organizationid, backoff_options, region)
 
     def create(self, name: str, visibility: SourceVisibility):
         return self.client.createSource(name, visibility)


### PR DESCRIPTION
This pull request is to review a simple fix to the platformclient.py and source.py classes that allow for a region parameter to be passed into the constructor. There is a default constructor value for region so that existing adoption of the SDK will continue to function. This is not a breaking change.